### PR TITLE
Fix search errors

### DIFF
--- a/frontend/class-frontend.php
+++ b/frontend/class-frontend.php
@@ -718,7 +718,7 @@ class WPSEO_Frontend {
 		$robots['follow'] = 'follow';
 		$robots['other']  = array();
 
-		if ( ( is_object( $post ) && is_singular() ) || ( WPSEO_Utils::is_woocommerce_active() && is_shop() ) ) {
+		if ( ( is_object( $post ) && is_singular() ) || ( WPSEO_Utils::is_woocommerce_active() && is_shop() && !is_search() ) ) {
 			$private = 'private' === $post->post_status;
 			$noindex = ! WPSEO_Post_Type::is_post_type_indexable( $post->post_type );
 


### PR DESCRIPTION
Some themes uses Woocommerce's archive-product.php template for search results. When 0 results are returned global $post variable will be null so there will be notice of "Trying to get property of non-object".

## Summary

This PR can be summarized in the following changelog entry:

* Fix error notices when using Woocommerce archive-product.php template for search results

## Relevant technical choices:

* I have added is_search() function to outcome situations where $post variable is used as object when it could be null.

## Test instructions

This PR can be tested by following these steps:

* Use theme which uses archive-product.php template file for search results.

## Quality assurance

* [x] I have tested this code to the best of my abilities
* [x] I have added unittests to verify the code works as intended

Fixes #10300
